### PR TITLE
Bugfix Configurations not re-defined in Adapter: Queue

### DIFF
--- a/storage/Queue.php
+++ b/storage/Queue.php
@@ -14,6 +14,12 @@ class Queue extends \lithium\core\Adaptable {
 	protected static $_adapters = 'adapter.queue';
 
 	/**
+	 * Re-define configurations to avoid overwrite configurations of other adapters
+	 * @var array the configurations 
+	 */
+	protected static $_configurations = array();
+
+	/**
 	 * @param string $task task name to queue
 	 * @param array $options Extra options
 	 * @return mixed Returned value by adapter's add() method


### PR DESCRIPTION
`static $_configurations` re-defined, as described in `lithium\core\Adaptable`. Problem occurs by using `li3_mailer` together with `li3_queue`. Same bug probably in `li3_mailer`. @see lithium\core\Adaptable
